### PR TITLE
feat: added included-users list

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,9 @@ inputs:
       Clubhouse story is successfully created. The template is populated
       with a `story` variable.
     default: "Clubhouse story: {{{ story.app_url }}}"
-  ignored-users:
+  included-users:
+    description: Comma-separated list of GitHub users to create Clubhouse stories. 
+  exluded-users:
     description: Comma-separated list of GitHub users to ignore. Often used for bots.
   user-map:
     description: Map GitHub usernames to Clubhouse UUIDs

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import { context } from "@actions/github";
 import { EventPayloads } from "@octokit/webhooks";
 import opened from "./opened";
 import closed from "./closed";
-import { getIgnoredUsers } from "./util";
+import { getExcludedUsers, getIncludedUsers } from "./util";
 
 async function run(): Promise<void> {
   if (context.eventName !== "pull_request") {
@@ -12,10 +12,20 @@ async function run(): Promise<void> {
   }
 
   const payload = context.payload as EventPayloads.WebhookPayloadPullRequest;
-  const ignoredUsers = getIgnoredUsers();
+  const excludedUsers = getExcludedUsers();
+  const includedUsers = getIncludedUsers();
   const author = payload.pull_request.user.login;
-  if (ignoredUsers.has(author)) {
-    core.debug(`ignored pull_request event from user ${author}`);
+  if(includedUsers) {
+    core.debug(`included-users is set ${includedUsers}. Only PRs from these users will create a Clubhouse story`)
+    if (includedUsers.has(author)) {
+      core.debug(`${author} is in included-users`);
+    }
+    else
+      return;
+  }
+
+  if (excludedUsers.has(author)) {
+    core.debug(`ignored pull_request event from user ${author} who is listed in exluded-users`);
     return;
   }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -29,13 +29,25 @@ function stringFromMap(map: Map<Stringable, Stringable>): string {
   return JSON.stringify(Object.fromEntries(Array.from(map.entries()).sort()));
 }
 
-export function getIgnoredUsers(): Set<string> {
+export function getExcludedUsers(): Set<string> {
   const s = new Set<string>();
-  const IGNORED_USERS = core.getInput("ignored-users");
-  if (!IGNORED_USERS) {
+  const EXCLUDED_USERS = core.getInput("excluded-users");
+  if (!EXCLUDED_USERS) {
     return s;
   }
-  for (const username of IGNORED_USERS.split(",")) {
+  for (const username of EXCLUDED_USERS.split(",")) {
+    s.add(username.trim());
+  }
+  return s;
+}
+
+export function getIncludedUsers(): Set<string> {
+  const s = new Set<string>();
+  const INCLUDED_USERS = core.getInput("included-users");
+  if (!INCLUDED_USERS) {
+    return s;
+  }
+  for (const username of INCLUDED_USERS.split(",")) {
     s.add(username.trim());
   }
   return s;
@@ -237,7 +249,7 @@ export async function createClubhouseStory(
   }
 
   const body: ClubhouseCreateStoryBody = {
-    name: payload.pull_request.title,
+    name: `${payload.repository.name} - ${payload.pull_request.title}`,
     description: payload.pull_request.body,
     project_id: clubhouseProject.id,
     external_tickets: [


### PR DESCRIPTION
Adding included-users list that allows us to set the list of users to create an automated Clubhouse story for. For example for dependabot PRs for which we want to track in our sprint cycles.